### PR TITLE
Port to scala-native 0.3.1+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.11"
 
 fork in run := true

--- a/project/p.sbt
+++ b/project/p.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-native" % "sbt-scala-native"  % "0.1.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.1")
 

--- a/src/main/scala/pcap.scala
+++ b/src/main/scala/pcap.scala
@@ -1,17 +1,31 @@
 package com.scalawilliam.scalanative
 
 import scala.scalanative.native
-import scala.scalanative.native.{CInt, CString}
+import scala.scalanative.native._
+import scala.scalanative.runtime.struct
 
 /**
   * @see https://linux.die.net/man/3/pcap
   */
-@native.link("pcap")
+@native.link("pcap") // Note: if using WinPcap, link against "wpcap" instead
 @native.extern
 object pcap {
 
   /** This is just a pointer for us, we don't care what is inside **/
   type pcap_handle = native.Ptr[Unit]
+
+  @struct class pcap_if {
+    var next: native.Ptr[pcap_if] = _
+    var name: native.Ptr[native.CChar] = _
+    var description: native.Ptr[native.CChar] = _
+    var addresses: native.Ptr[Unit] = _ // this is a pcap_addr*
+    var flags: native.CUnsignedInt = _ //new UInt(0)
+  }
+
+  def pcap_findalldevs(devs_out: Ptr[Ptr[pcap_if]],
+                       errbuf: CString): native.CInt = native.extern
+
+  def pcap_freealldevs(devices: native.Ptr[pcap_if]): Unit = native.extern
 
   type pcap_pkthdr = native.CStruct4[native.CUnsignedLong,
                                      native.CUnsignedLong,


### PR DESCRIPTION
I couldn't actually test on scala-native 0.3.1 since I only have a windows machine, and windows support is on a 0.4.0 fork.  However, I got your code to work on a 0.4.0 snapshot, and it should work in 0.3.1 also (since Zone was added in 0.3.0).  
The main change was zone allocation (http://scala-native.readthedocs.io/en/latest/user/interop.html), but I also added some cli args checking to confuse future users less (I was confused, since there was only an exception thrown when args were empty).

Also added a definition for pcap_findalldevs and pcap_freealldevs for enumerating devices, because deviceName = "any" was resulting in error.