### PR TITLE
Scalanative 0.3.1

### DIFF
--- a/project/p.sbt
+++ b/project/p.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-native" % "sbt-scala-native"  % "0.1.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native"  % "0.3.1")
 

--- a/src/main/scala/PcapExample.scala
+++ b/src/main/scala/PcapExample.scala
@@ -68,9 +68,9 @@ object PcapExample {
     println("...]")
   }
 
-  def main(args: Array[String]): Unit = Zone { zone => run(args)(zone) }
+  def main(args: Array[String]): Unit = Zone { implicit zone => run(args) }
 
-  def run(args: Array[String])(implicit zone:Zone): Unit = {
+  def run(args: Array[String])(implicit zone: Zone): Unit = {
     val cooked = args.contains("cooked")
     val live = !cooked
     val errorBuffer = native.stackalloc[Byte](256)

--- a/src/main/scala/PcapExample.scala
+++ b/src/main/scala/PcapExample.scala
@@ -2,13 +2,7 @@
 package com.scalawilliam.scalanative
 
 import scala.scalanative.native
-import scala.scalanative.native.{
-  CString,
-  CUnsignedInt,
-  Ptr,
-  fromCString,
-  toCString
-}
+import scala.scalanative.native._
 
 /**
   * This example app reads online and offline via libpcap.
@@ -69,12 +63,14 @@ object PcapExample {
         !(data + offsetBytes + n)
       }
       .foreach { v =>
-        native.stdio.printf(toCString("%02X"), v)
+        native.stdio.printf(c"%02X", v)
       }
     println("...]")
   }
 
-  def main(args: Array[String]): Unit = {
+  def main(args: Array[String]): Unit = Zone { zone => run(args)(zone) }
+
+  def run(args: Array[String])(implicit zone:Zone): Unit = {
     val cooked = args.contains("cooked")
     val live = args.contains("live")
     val errorBuffer = native.stackalloc[Byte](256)

--- a/src/main/scala/PcapExample.scala
+++ b/src/main/scala/PcapExample.scala
@@ -81,7 +81,7 @@ object PcapExample {
     val errorBuffer = native.stackalloc[Byte](256)
     val pcapHandle = if (live) {
       pcap.pcap_open_live(
-        deviceName = toCString("any"),
+        deviceName = c"any",
         snapLen = Short.MaxValue,
         promisc = 0,
         to_ms = 10,

--- a/src/main/scala/PcapExample.scala
+++ b/src/main/scala/PcapExample.scala
@@ -68,11 +68,16 @@ object PcapExample {
     println("...]")
   }
 
-  def main(args: Array[String]): Unit = Zone { implicit zone => run(args) }
+  def main(args: Array[String]): Unit = {
+    if (!args.isEmpty)
+      Zone { implicit zone => run(args) }
+    else
+      println("Incorrect usage.")
+  }
 
   def run(args: Array[String])(implicit zone: Zone): Unit = {
     val cooked = args.contains("cooked")
-    val live = !cooked
+    val live = args.contains("live")
     val errorBuffer = native.stackalloc[Byte](256)
     val pcapHandle = if (live) {
       pcap.pcap_open_live(

--- a/src/main/scala/PcapExample.scala
+++ b/src/main/scala/PcapExample.scala
@@ -72,7 +72,7 @@ object PcapExample {
 
   def run(args: Array[String])(implicit zone:Zone): Unit = {
     val cooked = args.contains("cooked")
-    val live = args.contains("live")
+    val live = !cooked
     val errorBuffer = native.stackalloc[Byte](256)
     val pcapHandle = if (live) {
       pcap.pcap_open_live(


### PR DESCRIPTION
Added support for scala-native 0.3.1.

I can only test 0.3.1 in your docker container, since I don't have a linux machine.  However in that container, there is no network traffic, so I can't check if it actually does anything.
I was able to test it (with slight modifications for winpcap) in a windows build on a fork of scala native 0.4.0 though, and that works.